### PR TITLE
Fix dynamic routes for movies and series

### DIFF
--- a/app/api/movies/route.ts
+++ b/app/api/movies/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import { ProwlarrClient } from '../../../lib/api/prowlarr-client';
 import { TMDbClient } from '../../../lib/api/tmdb-client';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET(request: Request) {
   try {
     // Get query parameters from the request URL

--- a/app/api/series/route.ts
+++ b/app/api/series/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import { ProwlarrClient } from '../../../lib/api/prowlarr-client';
 import { TMDbClient } from '../../../lib/api/tmdb-client';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET(request: Request) {
   try {
     // Get query parameters from the request URL


### PR DESCRIPTION
## Summary
- mark movies and series API routes as dynamic in Next.js

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68401cc94dac832580dd75fb3899e040