### PR TITLE
Implement Mongo-based admin categories

### DIFF
--- a/app/admin/categories/page.tsx
+++ b/app/admin/categories/page.tsx
@@ -1,0 +1,56 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+interface Category {
+  _id: string
+  title: string
+  type: 'movie' | 'tv'
+  order: number
+  enabled: boolean
+}
+
+export default function AdminCategoriesPage() {
+  const [categories, setCategories] = useState<Category[]>([])
+  const [form, setForm] = useState<Partial<Category>>({})
+
+  const fetchCategories = async () => {
+    const res = await fetch('/api/admin/categories')
+    const data = await res.json()
+    setCategories(data)
+  }
+
+  useEffect(() => { fetchCategories() }, [])
+
+  const submit = async () => {
+    await fetch('/api/admin/categories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    })
+    setForm({})
+    fetchCategories()
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Categories</h1>
+      <ul className="mb-6">
+        {categories.map(c => (
+          <li key={c._id}>{c.title} ({c.type}) {c.enabled ? '✅' : '❌'}</li>
+        ))}
+      </ul>
+      <div className="space-y-2">
+        <input className="border p-1" placeholder="id" value={form._id||''} onChange={e=>setForm({...form,_id:e.target.value})}/>
+        <input className="border p-1" placeholder="title" value={form.title||''} onChange={e=>setForm({...form,title:e.target.value})}/>
+        <select className="border p-1" value={form.type||''} onChange={e=>setForm({...form,type:e.target.value as 'movie'|'tv'})}>
+          <option value="">type</option>
+          <option value="movie">movie</option>
+          <option value="tv">tv</option>
+        </select>
+        <input className="border p-1" placeholder="order" type="number" value={form.order||''} onChange={e=>setForm({...form,order:Number(e.target.value)})}/>
+        <label><input type="checkbox" checked={form.enabled||false} onChange={e=>setForm({...form,enabled:e.target.checked})}/> enabled</label>
+        <button className="bg-blue-500 text-white px-2" onClick={submit}>Save</button>
+      </div>
+    </div>
+  )
+}

--- a/app/api/admin/categories/route.ts
+++ b/app/api/admin/categories/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { CategoryConfigService } from '@/lib/services/server/category-config-service';
+
+export async function GET() {
+  try {
+    const categories = await CategoryConfigService.getAllCategories();
+    return NextResponse.json(categories);
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to fetch categories' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    await CategoryConfigService.upsertCategory(body);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to save category' }, { status: 500 });
+  }
+}

--- a/lib/services/server/category-config-service.ts
+++ b/lib/services/server/category-config-service.ts
@@ -1,0 +1,51 @@
+import MongoService from './mongo-service';
+import { MongoFeaturedCategory, FEATURED_CATEGORIES_COLLECTION } from '../../types/mongo';
+
+export const DEFAULT_CATEGORIES: MongoFeaturedCategory[] = [
+  { _id: 'trending-now', title: 'Trending Now', type: 'movie', tmdbParams: { source: 'trendingMovies' }, order: 1, enabled: true },
+  { _id: 'popular-tv', title: 'Popular TV Shows', type: 'tv', tmdbParams: { source: 'popularTV' }, order: 2, enabled: true },
+  { _id: 'new-releases', title: 'New Releases', type: 'movie', tmdbParams: { source: 'newReleases' }, order: 3, enabled: true },
+  { _id: 'top-4k', title: 'Top 4K Content', type: 'movie', tmdbParams: { source: 'top4KContent' }, order: 4, enabled: true },
+  { _id: 'documentaries', title: 'Documentaries', type: 'movie', tmdbParams: { source: 'documentaries' }, order: 5, enabled: true },
+];
+
+export class CategoryConfigService {
+  private static initialized = false;
+
+  private static async getCollection() {
+    await MongoService.connect();
+    return MongoService.getDb().collection<MongoFeaturedCategory>(FEATURED_CATEGORIES_COLLECTION);
+  }
+
+  static async initialize() {
+    if (this.initialized) return;
+    const collection = await this.getCollection();
+    const count = await collection.countDocuments();
+    if (count === 0) {
+      await collection.insertMany(DEFAULT_CATEGORIES);
+    }
+    this.initialized = true;
+  }
+
+  static async getAllCategories(): Promise<MongoFeaturedCategory[]> {
+    await this.initialize();
+    const collection = await this.getCollection();
+    return collection.find().sort({ order: 1 }).toArray();
+  }
+
+  static async upsertCategory(cat: MongoFeaturedCategory): Promise<void> {
+    await this.initialize();
+    const collection = await this.getCollection();
+    await collection.updateOne(
+      { _id: cat._id },
+      { $set: { ...cat } },
+      { upsert: true }
+    );
+  }
+
+  static async deleteCategory(id: string): Promise<void> {
+    await this.initialize();
+    const collection = await this.getCollection();
+    await collection.deleteOne({ _id: id });
+  }
+}

--- a/lib/types/mongo.ts
+++ b/lib/types/mongo.ts
@@ -68,3 +68,12 @@ export interface MongoCuratedList extends MongoBaseDocument {
 
 export const MEDIA_ITEMS_COLLECTION = 'mediaItems';
 export const CURATED_LISTS_COLLECTION = 'curatedLists';
+export interface MongoFeaturedCategory extends MongoBaseDocument {
+  title: string;
+  type: 'movie' | 'tv';
+  tmdbParams?: Record<string, any>;
+  order: number;
+  enabled: boolean;
+}
+
+export const FEATURED_CATEGORIES_COLLECTION = 'featuredCategories';

--- a/test/app/api/admin/categories.test.ts
+++ b/test/app/api/admin/categories.test.ts
@@ -1,0 +1,32 @@
+const { __MONGODB_URI_SET__ } = vi.hoisted(() => {
+  process.env.MONGODB_URI = 'mongodb://mock-uri';
+  return { __MONGODB_URI_SET__: true };
+});
+
+import { describe, it, expect, vi } from 'vitest';
+import { GET, POST } from '../../../../app/api/admin/categories/route';
+import { CategoryConfigService } from '../../../../lib/services/server/category-config-service';
+
+vi.mock('../../../../lib/services/server/category-config-service');
+
+describe('admin categories api', () => {
+  it('should return categories', async () => {
+    vi.mocked(CategoryConfigService.getAllCategories).mockResolvedValue([
+      { _id: 'one', title: 'One', type: 'movie', order: 1, enabled: true }
+    ] as any);
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data[0]._id).toBe('one');
+  });
+
+  it('should save category', async () => {
+    vi.mocked(CategoryConfigService.upsertCategory).mockResolvedValue();
+    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({ _id: 'two' }) });
+    const res = await POST(req as any);
+    expect(CategoryConfigService.upsertCategory).toHaveBeenCalledWith({ _id: 'two' });
+    expect(res.status).toBe(200);
+  });
+});

--- a/test/lib/services/curator-service-category-config.test.ts
+++ b/test/lib/services/curator-service-category-config.test.ts
@@ -1,0 +1,39 @@
+const { __MONGODB_URI_SET__ } = vi.hoisted(() => {
+  process.env.MONGODB_URI = 'mongodb://mock-uri';
+  return { __MONGODB_URI_SET__: true };
+});
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchFreshFeaturedContent } from '../../../lib/services/server/curator-service';
+import { CategoryConfigService } from '../../../lib/services/server/category-config-service';
+import { TrendingContentClient } from '../../../lib/services/server/trending-content-client';
+
+vi.mock('../../../lib/services/server/category-config-service');
+vi.mock('../../../lib/services/server/trending-content-client');
+
+const mockClient = {
+  getTrendingMovies: vi.fn().mockResolvedValue([{ guid: 'a', indexerId: '1', title: 'A', protocol: 'torrent', mediaType: 'movie' }]),
+  getPopularTV: vi.fn().mockResolvedValue([{ guid: 'b', indexerId: '1', title: 'B', protocol: 'torrent', mediaType: 'tv' }]),
+  getNewReleases: vi.fn().mockResolvedValue([]),
+  get4KContent: vi.fn().mockResolvedValue([]),
+  getDocumentaries: vi.fn().mockResolvedValue([])
+};
+
+vi.mocked(TrendingContentClient).mockImplementation(() => mockClient as any);
+
+describe('CuratorService with category config', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(CategoryConfigService.getAllCategories).mockResolvedValue([
+      { _id: 'trending-now', title: 'Trending', type: 'movie', order: 1, enabled: true, tmdbParams: { source: 'trendingMovies' } },
+      { _id: 'popular-tv', title: 'Popular TV', type: 'tv', order: 2, enabled: true, tmdbParams: { source: 'popularTV' } },
+      { _id: 'disabled', title: 'Disabled', type: 'movie', order: 3, enabled: false, tmdbParams: { source: 'newReleases' } }
+    ] as any);
+  });
+
+  it('orders and filters categories', async () => {
+    const result = await fetchFreshFeaturedContent(new TrendingContentClient({} as any));
+    expect(result.categories[0].id).toBe('trending-now');
+    expect(result.categories).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add Mongo types for featured categories
- create `CategoryConfigService` to manage Mongo collection
- update `CuratorService` to fetch categories from Mongo
- add admin category API route and admin page
- test category management API and curator ordering

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68408edf302483258ed26c298af43266