### PR TITLE
Add cache API

### DIFF
--- a/app/admin/cache/page.tsx
+++ b/app/admin/cache/page.tsx
@@ -55,13 +55,13 @@ export default function AdminCachePage() {
     setIsLoading(true);
     setError(null);
     try {
-      const response = await fetch('/api/admin'); // Endpoint you created
+      const response = await fetch('/api/cache');
       if (!response.ok) {
         const errorData = await response.json();
         throw new Error(errorData.message || `Error: ${response.status}`);
       }
-      const data: FeaturedContent = await response.json();
-      setCachedData(data);
+      const data = await response.json();
+      setCachedData(data.featuredContent as FeaturedContent);
     } catch (err: unknown) {
       if (err instanceof Error) {
         setError(err.message);
@@ -89,8 +89,8 @@ export default function AdminCachePage() {
           
           <div className="flex flex-col space-y-4">
             {/* Link to check status - adjust if API endpoint differs */}
-            <Link 
-              href="/api/cache/refresh" // This might need to be a status check endpoint if different
+            <Link
+              href="/api/cache"
               className="inline-block bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded text-center font-medium transition-colors"
             >
               Check Cache Health/Status (Example)

--- a/app/api/cache/refresh/route.ts
+++ b/app/api/cache/refresh/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { CacheSchedulerService } from '@/lib/services/server/cache-scheduler';
+
+export async function POST(_request: NextRequest) {
+  try {
+    const result = await CacheSchedulerService.refreshCache();
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error('[api/cache/refresh] Failed to refresh cache:', error);
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Failed to refresh cache' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/cache/route.ts
+++ b/app/api/cache/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { CacheService } from '@/lib/services/server/cache-service';
+
+export async function GET() {
+  try {
+    const [valid, ttl, featuredContent] = await Promise.all([
+      CacheService.isFeaturedContentCacheValid(),
+      CacheService.getFeaturedContentCacheTimeRemaining(),
+      CacheService.getCachedFeaturedContent()
+    ]);
+
+    return NextResponse.json({
+      timestamp: new Date().toISOString(),
+      valid,
+      ttl,
+      featuredContent
+    });
+  } catch (error) {
+    console.error('[api/cache] Failed to get cache status:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to get cache status' },
+      { status: 500 }
+    );
+  }
+}

--- a/test/app/api/cache/routes.test.ts
+++ b/test/app/api/cache/routes.test.ts
@@ -1,0 +1,52 @@
+const { __MONGODB_URI_SET__ } = vi.hoisted(() => {
+  process.env.MONGODB_URI = 'mongodb://mock-uri';
+  return { __MONGODB_URI_SET__: true };
+});
+
+vi.mock('../../../../lib/services/server/cache-service', () => ({
+  CacheService: {
+    isFeaturedContentCacheValid: vi.fn(),
+    getFeaturedContentCacheTimeRemaining: vi.fn(),
+    getCachedFeaturedContent: vi.fn()
+  }
+}));
+
+vi.mock('../../../../lib/services/server/cache-scheduler', () => ({
+  CacheSchedulerService: {
+    refreshCache: vi.fn()
+  }
+}));
+
+import { describe, it, expect, vi } from 'vitest';
+import { GET } from '../../../../app/api/cache/route';
+import { POST } from '../../../../app/api/cache/refresh/route';
+import { CacheService } from '../../../../lib/services/server/cache-service';
+import { CacheSchedulerService } from '../../../../lib/services/server/cache-scheduler';
+
+describe('/api/cache routes', () => {
+  it('GET returns cache status', async () => {
+    vi.mocked(CacheService.isFeaturedContentCacheValid).mockResolvedValue(true);
+    vi.mocked(CacheService.getFeaturedContentCacheTimeRemaining).mockResolvedValue(42);
+    vi.mocked(CacheService.getCachedFeaturedContent).mockResolvedValue({ foo: 'bar' } as any);
+
+    const res = await GET();
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(true);
+    expect(data.ttl).toBe(42);
+    expect(data.featuredContent).toEqual({ foo: 'bar' });
+  });
+
+  it('POST triggers cache refresh', async () => {
+    vi.mocked(CacheSchedulerService.refreshCache).mockResolvedValue({ success: true } as any);
+
+    const req = new Request('http://test', { method: 'POST' });
+    const res = await POST(req as any);
+    const data = await res.json();
+
+    expect(CacheSchedulerService.refreshCache).toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ success: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add `/api/cache` GET route for cache status
- add `/api/cache/refresh` POST route to refresh cache
- update admin cache page to query new endpoints
- test cache API routes

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6841d830c9108325acb7f86d2e5f9e8a