### PR TITLE
Add build-apk instructions

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -1,1 +1,13 @@
-Placeholder for Android platform
+# Android Platform
+
+This directory contains the native Android project created by Capacitor.
+
+To build a debug APK from the repository root you can run:
+
+```bash
+npm run build-apk
+```
+
+The script copies the web assets and assembles the APK, which will be placed in `android/app/build/outputs/apk/debug/app-debug.apk`.
+
+See `../docs/android-firetv-build-guide.md` for a detailed guide.

--- a/docs/android-firetv-build-guide.md
+++ b/docs/android-firetv-build-guide.md
@@ -1,0 +1,30 @@
+# Android/Fire TV Build Guide
+
+This guide describes how to create a debug APK for running Torrent VideoClub on Amazon Fire TV devices.
+
+## Building Manually
+
+1. Install project dependencies and build the web assets:
+
+   ```bash
+   npm install
+   npm run build
+   ```
+
+2. Copy the web output into the Android project and assemble the debug APK:
+
+   ```bash
+   npx cap copy android && cd android && ./gradlew assembleDebug
+   ```
+
+3. The generated APK will be located at `android/app/build/outputs/apk/debug/app-debug.apk`.
+
+## Using the build-apk script
+
+Instead of running the manual command, you can use the npm script:
+
+```bash
+npm run build-apk
+```
+
+This performs the `npx cap copy android` and `./gradlew assembleDebug` steps for you and produces the same APK in `android/app/build/outputs/apk/debug/app-debug.apk`.


### PR DESCRIPTION
## Summary
- document how to build an Android/Fire TV APK with a handy script
- reference this script in the Android README

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6841e1daf77c8325b2086984b85a1427